### PR TITLE
feat: Complete signal and history

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: hannkim <hannkim@student.42seoul.kr>       +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2022/05/04 14:54:52 by hannkim           #+#    #+#              #
-#    Updated: 2022/06/21 23:38:15 by hannkim          ###   ########.fr        #
+#    Updated: 2022/06/22 17:58:13 by hannkim          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -35,7 +35,7 @@ LIB_HEADER		= /opt/homebrew/Cellar/readline/8.1.2/include
 # LIB_DIR="/usr/local/opt/readline/lib"
 # LIB_HEADER="/usr/local/opt/readline/include"
 
-LIB_FLAGS		= -lreadline -L $(LIB_DIR) -I $(LIB_HEADER)
+LIB_FLAGS		= -lreadline -L$(LIB_DIR) -I$(LIB_HEADER)
 
 SRC_PARSER_DIR	= parser/
 SRC_PARSER		= lexical_analyzer.c syntax_analyzer.c token.c \
@@ -63,6 +63,9 @@ SRC_TEST		= test_token.c test_ast.c
 SRC_EXEC_DIR	= exec/
 SRC_EXEC		= ft_execve.c
 
+SRC_SIGNAL_DIR	= signal/
+SRC_SIGNAL		= ft_signal.c ft_eof.c
+
 SRC				= main.c \
 					$(addprefix $(SRC_PARSER_DIR), $(SRC_PARSER)) \
 					$(addprefix $(SRC_BUILTIN_DIR), $(SRC_BUILTIN)) \
@@ -70,17 +73,18 @@ SRC				= main.c \
 					$(addprefix $(SRC_UTILS_DIR), $(SRC_UTILS)) \
 					$(addprefix $(SRC_ENV_DIR), $(SRC_ENV)) \
 					$(addprefix $(SRC_TEST_DIR), $(SRC_TEST)) \
-					$(addprefix $(SRC_EXEC_DIR), $(SRC_EXEC))
+					$(addprefix $(SRC_EXEC_DIR), $(SRC_EXEC)) \
+					$(addprefix $(SRC_SIGNAL_DIR), $(SRC_SIGNAL))
 
 SRCS			= $(addprefix $(SRCS_DIR), $(SRC))
 OBJS 			= $(SRCS:.c=.o)
 
 .c.o:
-	$(CC) $(CFLAGS) -I$(HEADERS) -o $@ -c $?
+	$(CC) $(CFLAGS) -I $(HEADERS) -I $(LIB_HEADER) -o $@ -c $?
 
 $(NAME): $(OBJS)
 	make -C $(LIBFT_DIR)
-	$(CC) $(CFLAGS) $(LIB_FLAGS) $(LIBFT_FLAGS) -I $(HEADERS) -o $(NAME) $(OBJS)
+	$(CC) $(CFLAGS) $(LIB_FLAGS) $(LIBFT_FLAGS) -o $(NAME) $(OBJS)
 
 .PHONY	: all
 all		: $(NAME)

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -5,8 +5,8 @@
 /*                                                    +:+ +:+         +:+     */
 /*   By: hannkim <hannkim@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2022/06/03 18:36:42 by nkim              #+#    #+#             */
-/*   Updated: 2022/06/21 23:32:52 by hannkim          ###   ########.fr       */
+/*   Created: 2022/06/22 18:35:25 by hannkim           #+#    #+#             */
+/*   Updated: 2022/06/22 18:35:27 by hannkim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,12 +15,13 @@
 
 # include "../libft/libft.h"
 # include "ast.h"
-# include <readline/readline.h>
 # include <stdio.h>
-# include <stdlib.h>
+# include <readline/readline.h>
+# include <readline/history.h>
 # include <string.h>
 # include <sys/errno.h>
 # include <sys/stat.h>
+# include <signal.h>
 
 # define NULL_LINE 0;
 # define ERROR_FLAG -1
@@ -87,5 +88,9 @@ void				remove_env(t_env *target);
 
 /* EXECUTE */
 void				ft_execve(char **argv);
+
+/* SIGNAL */
+void				exit_eof(char *command_line);
+void				ft_signal(void);
 
 #endif

--- a/src/exec/ft_execve.c
+++ b/src/exec/ft_execve.c
@@ -1,12 +1,12 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   cmd_execve.c                                       :+:      :+:    :+:   */
+/*   ft_execve.c                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: hannkim <hannkim@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/21 09:22:30 by hannkim           #+#    #+#             */
-/*   Updated: 2022/06/21 23:32:42 by hannkim          ###   ########.fr       */
+/*   Updated: 2022/06/22 18:27:07 by hannkim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -93,5 +93,7 @@ void	ft_execve(char **argv)
 		i++;
 	}
 	free(path);
+	signal(SIGQUIT, SIG_DFL);
 	execve(filename, argv, envp);
+	exit(EXIT_FAILURE);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: hannkim <hannkim@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/28 21:17:33 by nkim              #+#    #+#             */
-/*   Updated: 2022/06/21 23:32:26 by hannkim          ###   ########.fr       */
+/*   Updated: 2022/06/22 18:15:39 by hannkim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -64,9 +64,13 @@ int	main(int argc, char **argv, char **envp)
 		exit(EXIT_FAILURE);
 	}
 	initiate_env(envp);
+	ft_signal();
 	while (1)
 	{
 		command_line = readline("blackhole-shell$ ");
+		exit_eof(command_line);
+		if (*command_line)
+			add_history(command_line);
 		init_manger(command_line);
 		ast = syntax_analyzer();
 		test_ast(ast);

--- a/src/signal/ft_eof.c
+++ b/src/signal/ft_eof.c
@@ -1,0 +1,23 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_eof.c                                           :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: hannkim <hannkim@student.42seoul.kr>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/06/22 16:23:11 by hannkim           #+#    #+#             */
+/*   Updated: 2022/06/22 18:26:00 by hannkim          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+/* EOF : ctrl + d */
+void	exit_eof(char	*command_line)
+{
+	if (!command_line)
+	{
+		ft_putstr_fd("exit\n", STDERR_FILENO);
+		exit(EXIT_SUCCESS);
+	}
+}

--- a/src/signal/ft_signal.c
+++ b/src/signal/ft_signal.c
@@ -1,0 +1,31 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_signal.c                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: hannkim <hannkim@student.42seoul.kr>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/06/22 18:18:30 by hannkim           #+#    #+#             */
+/*   Updated: 2022/06/22 18:18:46 by hannkim          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+/* rl_replace_line : buffer flush */
+static void	handle_sigint(int signum)
+{
+	if (signum != SIGINT)
+		return ;
+	write(1, "\n", 1);
+	rl_replace_line("", 1);
+	rl_on_new_line();
+	rl_redisplay();
+}
+
+/* SIGINT : ctrl + c, SIGQUIT : ctrl + \ */
+void	ft_signal(void)
+{
+	signal(SIGINT, handle_sigint);
+	signal(SIGQUIT, SIG_IGN);
+}


### PR DESCRIPTION
## 개요
sinal (SIGINT, SIGQUIT) 및 history 처리

## 작업내용
SIGINT (ctrl + c) signal은 readline buffer flush 하고 새 prompt 띄움
SIGQUIT (ctrl + \) signal은 SIG_IGN로 무시함 -> execve 호출 전에 default로 돌려줌 (SIG_DFL)
readline에 문자가 존재하면 add_history 함수로 추가

## 주의사항
부모 프로세스, 자식 프로세스에서 핸들러 사용이 달라질 수 있음