### PR TITLE
Hotfix/pipe connect err

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: nkim <nkim@student.42seoul.kr>             +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2022/05/04 14:54:52 by hannkim           #+#    #+#              #
-#    Updated: 2022/06/27 18:03:22 by nkim             ###   ########.fr        #
+#    Updated: 2022/06/27 20:19:29 by nkim             ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -68,7 +68,8 @@ SRC_SUBSHELL_DIR= subshell/
 SRC_SUBSHELL	= wait_subshell.c create_subshell.c
 
 SRC_REDIRECT_DIR= redirect/
-SRC_REDIRECT	= redirect_in_file.c redirect_out_file.c redirect_append_file.c redirect_heredoc.c
+SRC_REDIRECT	= redirect_in_file.c redirect_out_file.c redirect_append_file.c \
+					redirect_heredoc.c backup_stdin_fd.c reset_stdin_fd.c
 
 SRC_MANAGER_DIR	= manager/
 SRC_MANAGER		=

--- a/src/exec/exec_ast.c
+++ b/src/exec/exec_ast.c
@@ -6,7 +6,7 @@
 /*   By: nkim <nkim@student.42seoul.kr>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/21 16:40:07 by nkim              #+#    #+#             */
-/*   Updated: 2022/06/26 21:32:08 by nkim             ###   ########.fr       */
+/*   Updated: 2022/06/27 20:21:21 by nkim             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -44,13 +44,26 @@ int	exec_command(t_command *command)
 
 int	exec_pipe_line(t_pipe_line *pipe_line)
 {
+	int	flag;
+	int	backup_fd;
+
+	flag = SUCCESS_FLAG;
 	if (pipe_line->pipe_line)
-		return (exec_subshell(pipe_line));
+	{
+		backup_stdin_fd(&backup_fd);
+		flag = exec_subshell(pipe_line);
+		reset_stdin_fd(backup_fd);
+	}
 	else if (pipe_line->command && pipe_line->command->type == AST_COMMAND)
-		return (exec_single_command(pipe_line->command->data));
+	{
+		flag = exec_single_command(pipe_line->command->data);
+	}
 	else
+	{
+		flag = ERROR_FLAG;
 		printf("empty pipeline\n");
-	return (ERROR_FLAG);
+	}
+	return (flag);
 }
 
 int	exec_ast(t_ast *ast)

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: nkim <nkim@student.42seoul.kr>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/28 21:17:33 by nkim              #+#    #+#             */
-/*   Updated: 2022/06/27 18:09:57 by nkim             ###   ########.fr       */
+/*   Updated: 2022/06/27 18:16:27 by nkim             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -48,7 +48,6 @@ int	main(int argc, char **argv, char **envp)
 	{
 		check_signal();
 		command_line = readline(PS1);
-		printf("after cmd line : %s\n", command_line);
 		ft_exit_eof(command_line);
 		if (*command_line)
 			add_history(command_line);

--- a/src/parser/token.c
+++ b/src/parser/token.c
@@ -6,7 +6,7 @@
 /*   By: nkim <nkim@student.42seoul.kr>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/20 04:36:17 by nkim              #+#    #+#             */
-/*   Updated: 2022/06/22 22:00:18 by nkim             ###   ########.fr       */
+/*   Updated: 2022/06/27 20:24:35 by nkim             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,6 +28,7 @@ t_token	get_token(void)
 	if (g_manager.rc >= ft_strlen(g_manager.command_line))
 		return (token); // EOF error
 	lexical_analyzer(&token, &begin, &end);
+	printf("token_type: %d, token_value: %s\n", token.type, token.value);
 	token.value = ft_calloc(end - begin + 1, sizeof(char));
 	if (!token.value)
 		return (token); // malloc error

--- a/src/redirect/backup_stdin_fd.c
+++ b/src/redirect/backup_stdin_fd.c
@@ -1,26 +1,21 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   redirect.h                                         :+:      :+:    :+:   */
+/*   backup_stdin_fd.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: nkim <nkim@student.42seoul.kr>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2022/06/26 18:27:34 by nkim              #+#    #+#             */
-/*   Updated: 2022/06/27 20:18:36 by nkim             ###   ########.fr       */
+/*   Created: 2022/06/27 18:29:57 by nkim              #+#    #+#             */
+/*   Updated: 2022/06/27 19:14:48 by nkim             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#ifndef REDIRECT_H
-# define REDIRECT_H
+#include "minishell.h"
 
-# include <fcntl.h>
-# include <unistd.h>
-
-int	redirect_in_file(char *file_path);
-int	redirect_out_file(char *file_path);
-int	redirect_append_file(char *file_path);
-int	redirect_heredoc(char *end_text);
-int	backup_stdin_fd(int *fd);
-int	reset_stdin_fd(int fd);
-
-#endif
+int	backup_stdin_fd(int *fd)
+{
+	*fd = dup(STDIN_FILENO);
+	if (*fd == -1)
+		return (throw_error("dup", NULL, strerror(errno)));
+	return (SUCCESS_FLAG);
+}

--- a/src/redirect/reset_stdin_fd.c
+++ b/src/redirect/reset_stdin_fd.c
@@ -1,26 +1,22 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   redirect.h                                         :+:      :+:    :+:   */
+/*   reset_stdin_fd.c                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: nkim <nkim@student.42seoul.kr>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2022/06/26 18:27:34 by nkim              #+#    #+#             */
-/*   Updated: 2022/06/27 20:18:36 by nkim             ###   ########.fr       */
+/*   Created: 2022/06/27 19:11:30 by nkim              #+#    #+#             */
+/*   Updated: 2022/06/27 20:23:45 by nkim             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#ifndef REDIRECT_H
-# define REDIRECT_H
+#include "minishell.h"
 
-# include <fcntl.h>
-# include <unistd.h>
-
-int	redirect_in_file(char *file_path);
-int	redirect_out_file(char *file_path);
-int	redirect_append_file(char *file_path);
-int	redirect_heredoc(char *end_text);
-int	backup_stdin_fd(int *fd);
-int	reset_stdin_fd(int fd);
-
-#endif
+int	reset_stdin_fd(int fd)
+{
+	if (dup2(fd, STDIN_FILENO) == -1)
+		return (throw_error("dup2", NULL, strerror(errno)));
+	if (close(fd) == -1)
+		return (throw_error("close", NULL, strerror(errno)));
+	return (SUCCESS_FLAG);
+}

--- a/src/subshell/create_subshell.c
+++ b/src/subshell/create_subshell.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   create_subshell.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: hannkim <hannkim@student.42seoul.kr>       +#+  +:+       +#+        */
+/*   By: nkim <nkim@student.42seoul.kr>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/26 18:24:53 by nkim              #+#    #+#             */
-/*   Updated: 2022/06/27 18:00:40 by hannkim          ###   ########.fr       */
+/*   Updated: 2022/06/27 20:24:56 by nkim             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,6 +28,7 @@ void	connect_pipe(int pipe_fd[2], int pipe_type)
 }
 
 // TODO: fork 위에 signal 처리??
+// printf("pipe_rd: %d, pipe_wr: %d\n", pipe_fd[READ], pipe_fd[WRITE]);
 pid_t	create_subshell(t_pipe_line *pipe_line)
 {
 	static int	pipe_fd[2];
@@ -38,7 +39,6 @@ pid_t	create_subshell(t_pipe_line *pipe_line)
 		throw_error("pipe", NULL, strerror(errno));
 		return (ERROR_FLAG);
 	}
-	printf("pipe_rd: %d, pipe_wr: %d\n", pipe_fd[READ], pipe_fd[WRITE]);
 	reset_signal();
 	pid = fork();
 	if (pid < 0)


### PR DESCRIPTION
## 개요
- Pipe 연결과정에서 마지막 프로세스의 `stdin` 이 `pipe_fd[0]` 으로 설정되어 있는 문제 발견 및 해결

## 작업내용
- 기존 `stdin` backup 및 reset 함수 추가
- `create_subshell` 부분의 에러 코드 수정

## 주의사항
