### PR TITLE
[Fix] Multi heredoc redirect_op segfault error

### DIFF
--- a/include/exec.h
+++ b/include/exec.h
@@ -6,7 +6,7 @@
 /*   By: nkim <nkim@student.42seoul.kr>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/26 21:26:05 by nkim              #+#    #+#             */
-/*   Updated: 2022/06/30 17:39:36 by nkim             ###   ########.fr       */
+/*   Updated: 2022/07/01 02:36:38 by nkim             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,8 +15,8 @@
 
 # include "ast.h"
 
-int	exec_command_line(t_ast *ast);
-int	exec_heredoc(t_ast *ast);
+int	exec_command_line(t_ast **ast);
+int	exec_heredoc(t_ast **ast);
 int	exec_builtin(char **argv);
 int	exec_general(char **argv);
 int	exec_ast(t_ast *ast);

--- a/src/exec/exec_command_line.c
+++ b/src/exec/exec_command_line.c
@@ -6,7 +6,7 @@
 /*   By: nkim <nkim@student.42seoul.kr>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/21 16:40:07 by nkim              #+#    #+#             */
-/*   Updated: 2022/06/30 17:40:03 by nkim             ###   ########.fr       */
+/*   Updated: 2022/07/01 03:04:31 by nkim             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -66,11 +66,11 @@ int	exec_ast(t_ast *ast)
 		return (ERROR_FLAG);
 }
 
-int	exec_command_line(t_ast *ast)
+int	exec_command_line(t_ast **ast)
 {
 	if (exec_heredoc(ast))
 		return (ERROR_FLAG);
-	if (exec_ast(ast))
+	if (exec_ast(*ast))
 		return (ERROR_FLAG);
 	return (SUCCESS_FLAG);
 }

--- a/src/exec/exec_heredoc.c
+++ b/src/exec/exec_heredoc.c
@@ -6,7 +6,7 @@
 /*   By: nkim <nkim@student.42seoul.kr>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/30 04:50:24 by nkim              #+#    #+#             */
-/*   Updated: 2022/07/01 03:04:22 by nkim             ###   ########.fr       */
+/*   Updated: 2022/07/01 15:33:04 by nkim             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,6 +38,8 @@ static int	exec_redirect_heredoc(t_ast **ast)
 	t_redirects		*redirects;
 	t_io_redirect	*io_redirect;
 
+	token.type = T_NULL;
+	token.value = NULL;
 	flag = SUCCESS_FLAG;
 	redirects = NULL;
 	io_redirect = NULL;

--- a/src/exec/exec_heredoc.c
+++ b/src/exec/exec_heredoc.c
@@ -6,33 +6,58 @@
 /*   By: nkim <nkim@student.42seoul.kr>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/30 04:50:24 by nkim              #+#    #+#             */
-/*   Updated: 2022/07/01 01:42:27 by nkim             ###   ########.fr       */
+/*   Updated: 2022/07/01 03:04:22 by nkim             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-static int	exec_redirect_heredoc(t_ast *ast)
+char	*create_heredoc_path(void)
+{
+	unsigned static int	cnt;
+	char				*cnt_arr;
+	char				*heredoc_path;
+	char				*tmpdir;
+
+	if (get_env(TMPENV) == NULL)
+		tmpdir = ft_strjoin(TMPDIR, TMPKEY);
+	else
+		tmpdir = ft_strjoin(get_env(TMPENV)->value, TMPKEY);
+	cnt_arr = ft_itoa(cnt);
+	heredoc_path = ft_strjoin(tmpdir, cnt_arr);
+	free(tmpdir);
+	free(cnt_arr);
+	cnt++;
+	return (heredoc_path);
+}
+
+static int	exec_redirect_heredoc(t_ast **ast)
 {
 	int				flag;
+	t_token			token;
 	t_redirects		*redirects;
 	t_io_redirect	*io_redirect;
 
 	flag = SUCCESS_FLAG;
 	redirects = NULL;
 	io_redirect = NULL;
-	if (ast && ast->type == AST_REDIRECTS)
-		redirects = ast->data;
+	if (*ast && (*ast)->type == AST_REDIRECTS)
+		redirects = (*ast)->data;
 	if (redirects && redirects->io_redirect)
 		io_redirect = redirects->io_redirect;
 	if (io_redirect->redirect_op == R_HEREDOC)
+	{
+		if (io_redirect->end_text == NULL)
+			return (throw_error_syntax(token));
+		io_redirect->file_path = create_heredoc_path();
 		flag = redirect_heredoc(io_redirect->end_text, io_redirect->file_path);
+	}
 	if (redirects->redirects)
-		flag |= exec_redirect_heredoc(redirects->redirects);
+		flag |= exec_redirect_heredoc(&redirects->redirects);
 	return (flag);
 }
 
-int	exec_heredoc(t_ast *ast)
+int	exec_heredoc(t_ast **ast)
 {
 	int			flag;
 	t_pipe_line	*pipe_line;
@@ -41,13 +66,13 @@ int	exec_heredoc(t_ast *ast)
 	flag = SUCCESS_FLAG;
 	pipe_line = NULL;
 	command = NULL;
-	if (ast && ast->type == AST_PIPELINE)
-		pipe_line = ast->data;
+	if (*ast && (*ast)->type == AST_PIPELINE)
+		pipe_line = (*ast)->data;
 	if (pipe_line && pipe_line->command->type == AST_COMMAND)
 		command = pipe_line->command->data;
 	if (command && command->redirects)
-		flag = exec_redirect_heredoc(command->redirects);
+		flag = exec_redirect_heredoc(&command->redirects);
 	if (pipe_line && pipe_line->pipe_line)
-		flag |= exec_heredoc(pipe_line->pipe_line);
+		flag |= exec_heredoc(&pipe_line->pipe_line);
 	return (flag);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: nkim <nkim@student.42seoul.kr>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/28 21:17:33 by nkim              #+#    #+#             */
-/*   Updated: 2022/07/01 01:11:42 by nkim             ###   ########.fr       */
+/*   Updated: 2022/07/01 03:07:46 by nkim             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -58,8 +58,9 @@ int	main(int argc, char **argv, char **envp)
 			add_history(command_line);
 			init_manger(command_line);
 			ast = syntax_analyzer();
+			test_ast(ast);
 			if (ast && g_manager.exit_code == EXIT_SUCCESS)
-				exec_command_line(ast);
+				exec_command_line(&ast);
 			reset_minishell(ast, std_fd);
 		}
 		free(command_line);

--- a/src/parser/get_combined_word.c
+++ b/src/parser/get_combined_word.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   get_combined_word.c                                :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: hannkim <hannkim@student.42seoul.kr>       +#+  +:+       +#+        */
+/*   By: nkim <nkim@student.42seoul.kr>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/23 16:54:25 by nkim              #+#    #+#             */
-/*   Updated: 2022/06/30 18:13:22 by hannkim          ###   ########.fr       */
+/*   Updated: 2022/07/01 15:08:14 by nkim             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,16 +20,14 @@
 char	*get_combined_heredoc_word(void)
 {
 	char	*combined_word;
-	char	*token;
 	char	*word;
 	char	*tmp;
 	char	next;
 
 	next = g_manager.command_line[g_manager.rc];
-	token = match(T_WORD);
-	if (!token)
+	if (fetch_token(GET).type != T_WORD)
 		return (NULL);
-	combined_word = syntax_heredoc_word(token);
+	combined_word = syntax_heredoc_word(match(T_WORD));
 	while (!bs_isspace(next) && fetch_token(GET).type == T_WORD)
 	{
 		next = g_manager.command_line[g_manager.rc];

--- a/src/parser/syntax_io_redirect.c
+++ b/src/parser/syntax_io_redirect.c
@@ -6,30 +6,11 @@
 /*   By: nkim <nkim@student.42seoul.kr>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/20 04:59:57 by nkim              #+#    #+#             */
-/*   Updated: 2022/06/30 21:55:54 by nkim             ###   ########.fr       */
+/*   Updated: 2022/07/01 15:04:00 by nkim             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
-
-char	*create_heredoc_path(void)
-{
-	unsigned static int	cnt;
-	char				*cnt_arr;
-	char				*heredoc_path;
-	char				*tmpdir;
-
-	if (get_env(TMPENV) == NULL)
-		tmpdir = ft_strjoin(TMPDIR, TMPKEY);
-	else
-		tmpdir = ft_strjoin(get_env(TMPENV)->value, TMPKEY);
-	cnt_arr = ft_itoa(cnt);
-	heredoc_path = ft_strjoin(tmpdir, cnt_arr);
-	free(tmpdir);
-	free(cnt_arr);
-	cnt++;
-	return (heredoc_path);
-}
 
 /*
 	syntax_io_redirect
@@ -50,17 +31,16 @@ int	syntax_io_redirect(t_io_redirect **io_redirect)
 	else if (!ft_strncmp(redirect_op, ">>", 3))
 		(*io_redirect)->redirect_op = R_APPEND;
 	else if (!ft_strncmp(redirect_op, "<<", 3))
-	{
 		(*io_redirect)->redirect_op = R_HEREDOC;
-		(*io_redirect)->file_path = create_heredoc_path();
-	}
+	else
+		return (ERROR_FLAG);
 	free(redirect_op);
 	if ((*io_redirect)->redirect_op == R_HEREDOC)
 		(*io_redirect)->end_text = get_combined_heredoc_word();
 	else
 		(*io_redirect)->file_path = get_combined_word();
-	if ((*io_redirect)->redirect_op == R_HEREDOC && !(*io_redirect)->end_text)
-		return (ERROR_FLAG);
+	if ((*io_redirect)->redirect_op == R_HEREDOC)
+		return (SUCCESS_FLAG);
 	if (!(*io_redirect)->file_path)
 		return (ERROR_FLAG);
 	return (SUCCESS_FLAG);


### PR DESCRIPTION
## 개요
- 여러 heredoc 들어왔을 때 `syntax error` 와 처리 순서 변경

## 작업내용
- `heredoc` syntax error 는 `exec_heredoc` 에서 처리하도록 변경
- `heredoc` 은 먼저 실행된 후 마지막에 `syntax_error` 받도록 수정

## 주의사항
