### PR TITLE
[Fix] syntax_redirect parsing error

### DIFF
--- a/src/exec/exec_single_command.c
+++ b/src/exec/exec_single_command.c
@@ -6,7 +6,7 @@
 /*   By: nkim <nkim@student.42seoul.kr>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/26 21:18:52 by nkim              #+#    #+#             */
-/*   Updated: 2022/07/03 17:52:09 by nkim             ###   ########.fr       */
+/*   Updated: 2022/07/03 20:05:32 by nkim             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -61,6 +61,7 @@ int	exec_single_command(t_command *command)
 	if (command->simple_command
 		&& is_builtin(command->simple_command->exec_path))
 		return (exec_single_builtin(command->simple_command));
-	else
+	else if (command->simple_command)
 		return (exec_single_general(command->simple_command));
+	return (flag);
 }

--- a/src/parser/syntax_redirects.c
+++ b/src/parser/syntax_redirects.c
@@ -6,7 +6,7 @@
 /*   By: nkim <nkim@student.42seoul.kr>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/20 04:59:05 by nkim              #+#    #+#             */
-/*   Updated: 2022/07/01 16:08:05 by nkim             ###   ########.fr       */
+/*   Updated: 2022/07/03 20:18:37 by nkim             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,15 +25,11 @@ static void	init_syntax_redirects(t_ast **ast_redirects)
 */
 int	syntax_redirects(t_ast **ast_redirects)
 {
-	int			flag;
 	t_redirects	*redirects;
 
-	flag = SUCCESS_FLAG;
 	init_syntax_redirects(ast_redirects);
 	redirects = (*ast_redirects)->data;
 	if (syntax_io_redirect(&redirects->io_redirect))
 		return (ERROR_FLAG);
-	if (fetch_token(GET).type == T_REDIRECT)
-		flag |= syntax_redirects(&redirects->redirects);
-	return (flag);
+	return (SUCCESS_FLAG);
 }


### PR DESCRIPTION
## 개요
- syntax_redirect parsing error

## 작업내용
- syntax_redirect parsing error
- syntax_command 반복적 파싱으로 변경 (이전, redirect 재귀적 파싱)

## 주의사항
